### PR TITLE
Add RAM_SIZE option to ps-exe.ld

### DIFF
--- a/ps-exe.ld
+++ b/ps-exe.ld
@@ -29,11 +29,12 @@ OUTPUT_FORMAT("binary")
 EXTERN(_start)
 ENTRY(_start)
 
+RAM_SIZE = DEFINED(RAM_SIZE) ? RAM_SIZE : 2M;
 TLOAD_ADDR = DEFINED(TLOAD_ADDR) ? TLOAD_ADDR : 0x80010000;
 
 MEMORY {
     loader      : ORIGIN = (TLOAD_ADDR - 0x800), LENGTH = 2048
-    ram (rwx)   : ORIGIN = TLOAD_ADDR, LENGTH = 2M - (TLOAD_ADDR - 0x80000000)
+    ram (rwx)   : ORIGIN = TLOAD_ADDR, LENGTH = RAM_SIZE - (TLOAD_ADDR - 0x80000000)
     dcache      : ORIGIN = 0x1f800000, LENGTH = 0x400
 }
 
@@ -84,7 +85,7 @@ SECTIONS {
         LONG(0); LONG(0);
 
         /* 0x0030 - 0x0033 :  Initial stack address. */
-        LONG(DEFINED(_sp) ? ABSOLUTE(_sp) : 0x801FFF00);
+        LONG(DEFINED(_sp) ? ABSOLUTE(_sp) : __sp);
 
         /* 0x0034 - 0x0037 : Initial stack size, set it to 0. */
         LONG(0);


### PR DESCRIPTION
Adds a RAM_SIZE option to ps-exe.ld which can be set through LDFLAGS to change the size of the ram block, as well as set the stack pointer appropriately so that PSYQo's allocator knows to use the full range.